### PR TITLE
Fix repo Widget on windows computers

### DIFF
--- a/layouts/partials/docs/repo.html
+++ b/layouts/partials/docs/repo.html
@@ -28,6 +28,7 @@
             <ul class="list-unstyled">
                 {{- if $.File -}}
                 {{- $filePath := printf "%s/%s%s" $branch $subPath (strings.TrimPrefix $root $.File.Filename) -}}
+                {{- $filePath = replace $filePath "\\" "/" -}}
                 <li class="mb-1">
                     <a href="{{ printf $sourceUrlFormat $url $filePath }}" target="_blank" rel="noopener noreferrer">
                         <i class="fas fa-fw fa-file-archive text-success"></i> {{ i18n "repo_action_view" }}


### PR DESCRIPTION
Fix repo widget creating link with backslashes when hugo is running on windows

